### PR TITLE
README: update the official documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Q3A, but I imagine that similar steps and configuration files could be used for
 other games that use this engine.
 
 You can read more about this on the
-[official ioquake3 documentation](http://wiki.ioquake3.org/Sys_Admin_Guide).
+[official ioquake3 documentation (archived)](https://web.archive.org/web/20160126100116/http://wiki.ioquake3.org/Sys_Admin_Guide#So.2C_You.27ve_Decided_to_Start_a_Dedicated_Quake_3:_Arena_Server.).
 See
 [here](http://www.3dgw.com/guides/q3a/index.php3?page=configs.htm#servercfg) and
 [here](https://www.quake3world.com/q3guide/servers.html) for more information about


### PR DESCRIPTION
The official documentation URL now points to a 404 page. Internet Archive (WebArchive) seems to have a copy of that page, so it would be better to link that instead.

Thank you.